### PR TITLE
Fix: Update build:gh-pages script to use index.html

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "start": "npx vite dev",
         "demos": "npx vite dev --open /demos.html",
         "build:watch": "vite build --watch",
-        "build:gh-pages": "npm run build && (npm run docs:build || true) && rm -rf docs/dist docs/js docs/index.html docs/example-*.html docs/index.css && mkdir -p docs/js docs/dist && cp demos.html docs/index.html && cp example-*.html docs/ && cp js/demo-launcher.js docs/js/demo-launcher.js && cp -R dist/. docs/dist/ && cp index.css docs/index.css"
+        "build:gh-pages": "npm run build && (npm run docs:build || true) && rm -rf docs/dist docs/js docs/index.html docs/example-*.html docs/index.css && mkdir -p docs/js docs/dist && cp index.html docs/index.html && cp example-*.html docs/ && cp js/demo-launcher.js docs/js/demo-launcher.js && cp -R dist/. docs/dist/ && cp index.css docs/index.css"
     },
     "author": "SpaceGraph Contributors",
     "license": "MIT",


### PR DESCRIPTION
The `build:gh-pages` script in `package.json` was attempting to copy `demos.html` to `docs/index.html`. However, `demos.html` was removed in a previous commit as its functionality was merged into `index.html`.

This commit updates the script to correctly copy `index.html` to `docs/index.html`, resolving the "cannot stat 'demos.html'" error that caused the script to fail.

The JSDoc errors during the `docs:build` part of the script still persist and are unrelated to this change.