### PR TITLE
Fix: Ensure docs directory exists for gh-pages artifact

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -38,7 +38,7 @@ jobs:
         run: npm run build:gh-pages # This script populates the ./docs directory
 
       - name: Verify build output
-        run: ls -F # List files and directories to confirm 'dist' exists
+        run: ls -RF docs/ # List files and directories to confirm 'docs' exists and its content
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "start": "npm run build && npx vite dev",
         "demos": "npm run build && npx vite dev --open /demos.html",
         "build:watch": "vite build --watch",
-        "build:gh-pages": "npm run build && npm run build:demo && (npm run docs:build || true) && rm -rf docs/dist docs/js docs/index.html docs/example-*.html docs/index.css docs/lib && mkdir -p docs/js docs/dist docs/lib && cp -R dist-demo/* docs/ && cp -R dist/* docs/lib/ && cp example-*.html docs/ 2>/dev/null || true && cp js/demo-launcher.js docs/js/demo-launcher.js 2>/dev/null || true && cp index.css docs/index.css 2>/dev/null || true"
+    "build:gh-pages": "mkdir -p docs/api && npm run build && npm run build:demo && (npm run docs:build || true) && rm -rf docs/dist docs/js docs/index.html docs/example-*.html docs/index.css docs/lib && mkdir -p docs/js docs/dist docs/lib && cp -R dist-demo/* docs/ && cp -R dist/* docs/lib/ && cp example-*.html docs/ 2>/dev/null || true && cp js/demo-launcher.js docs/js/demo-launcher.js 2>/dev/null || true && cp index.css docs/index.css 2>/dev/null || true"
     },
     "author": "SpaceGraph Contributors",
     "license": "MIT",


### PR DESCRIPTION
This commit addresses an error in the GitHub Pages deployment workflow where the `docs/` directory was not found during the artifact upload step.

Changes:
1. Modified `.github/workflows/gh-pages.yml`:
   - Changed the `Verify build output` step to `ls -RF docs/` to provide more detailed logging of the `docs/` directory's contents (or absence) before the upload attempt.

2. Modified `package.json` (`build:gh-pages` script):
   - Added `mkdir -p docs/api` at the very beginning of the script. This ensures that the `docs/` directory and its `api/` subdirectory (used by JSDoc) are created before any other operations, making the script more robust.

These changes aim to prevent the `tar: docs: Cannot open: No such file or directory` error and ensure the GitHub Pages site is deployed correctly.