### PR TITLE
Fix: Ensure CameraPlugin initializes before RenderingPlugin

### DIFF
--- a/src/core/SpaceGraph.js
+++ b/src/core/SpaceGraph.js
@@ -44,10 +44,10 @@ export class SpaceGraph {
         this.confirmDialogElement = confirmDialogElement; // Added
         this.plugins = new PluginManager(this);
 
-        // Register RenderingPlugin
-        this.plugins.add(new RenderingPlugin(this, this.plugins));
-        // Register CameraPlugin
+        // Register CameraPlugin FIRST
         this.plugins.add(new CameraPlugin(this, this.plugins));
+        // Register RenderingPlugin SECOND
+        this.plugins.add(new RenderingPlugin(this, this.plugins));
         // Register NodePlugin
         this.plugins.add(new NodePlugin(this, this.plugins));
         // Register EdgePlugin


### PR DESCRIPTION
Reordered plugin registration in `SpaceGraph.js` to ensure that the `CameraPlugin` is initialized before the `RenderingPlugin`.

This resolves a runtime error where the `RenderingPlugin` would attempt to access the camera instance before it was created, leading to errors during renderer and post-processing setup on the deployed GitHub Pages demo.