### PR TITLE
Fix: Add guards to prevent crash if geometry has no points before set…

### DIFF
--- a/src/graph/CurvedEdge.js
+++ b/src/graph/CurvedEdge.js
@@ -120,11 +120,15 @@ export class CurvedEdge extends Edge {
                 const interpolatedColor = new THREE.Color().lerpColors(colorStart, colorEnd, t);
                 curveColors.push(interpolatedColor.r, interpolatedColor.g, interpolatedColor.b);
             }
-            this.line.geometry.setColors(curveColors);
-            if (this.line.geometry.attributes.instanceColorStart)
-                this.line.geometry.attributes.instanceColorStart.needsUpdate = true;
-            if (this.line.geometry.attributes.instanceColorEnd)
-                this.line.geometry.attributes.instanceColorEnd.needsUpdate = true;
+            if (this.line.geometry.attributes.position && this.line.geometry.attributes.position.count > 0) {
+                this.line.geometry.setColors(curveColors);
+                if (this.line.geometry.attributes.instanceColorStart)
+                    this.line.geometry.attributes.instanceColorStart.needsUpdate = true;
+                if (this.line.geometry.attributes.instanceColorEnd)
+                    this.line.geometry.attributes.instanceColorEnd.needsUpdate = true;
+            } else {
+                console.warn(`CurvedEdge ${this.id}: Skipping setColors in update() due to empty geometry positions.`);
+            }
         } else {
             // Ensure no gradient if not specified (similar to Edge.js update)
             if (this.line.material.vertexColors) {

--- a/src/graph/Edge.js
+++ b/src/graph/Edge.js
@@ -148,9 +148,13 @@ export class Edge {
         // For base Edge.js, it's always 2 points.
         // CurvedEdge will need to override this part if it wants a gradient over many segments.
 
-        this.line.geometry.setColors(colors);
-        this.line.geometry.attributes.instanceColorStart.needsUpdate = true;
-        this.line.geometry.attributes.instanceColorEnd.needsUpdate = true;
+        if (this.line.geometry.attributes.position && this.line.geometry.attributes.position.count > 0) {
+            this.line.geometry.setColors(colors);
+            if (this.line.geometry.attributes.instanceColorStart) this.line.geometry.attributes.instanceColorStart.needsUpdate = true;
+            if (this.line.geometry.attributes.instanceColorEnd) this.line.geometry.attributes.instanceColorEnd.needsUpdate = true;
+        } else {
+            console.warn(`Edge ${this.id}: Skipping setColors in _setGradientColors due to empty geometry positions.`);
+        }
     }
 
     update() {


### PR DESCRIPTION
…Colors

Added checks in Edge.js and CurvedEdge.js to ensure that `this.line.geometry.attributes.position.count > 0` before calling `this.line.geometry.setColors()`.

This is a defensive measure to prevent the 'Invalid typed array length: -6'\error that occurs if `setColors` is called on a LineGeometry with 0 points. Includes console warnings if the condition is met, to help diagnose the underlying cause of the empty geometry.