### PR TITLE
Fix: Add defensive checks to prevent Three.js rendering errors

### DIFF
--- a/src/graph/nodes/BaseNode.js
+++ b/src/graph/nodes/BaseNode.js
@@ -14,7 +14,12 @@ export class BaseNode {
 
     constructor(id, position = { x: 0, y: 0, z: 0 }, data = {}, mass = 1.0) {
         this.id = id ?? Utils.generateId('node');
-        this.position.set(position.x, position.y, position.z);
+        if (!isFinite(position.x) || !isFinite(position.y) || !isFinite(position.z)) {
+            console.warn(`BaseNode ${this.id}: Initial position is invalid (${position.x}, ${position.y}, ${position.z}). Defaulting to (0,0,0).`);
+            this.position.set(0, 0, 0);
+        } else {
+            this.position.set(position.x, position.y, position.z);
+        }
         this.data = Utils.mergeDeep({}, this.getDefaultData(), data);
         this.mass = Math.max(0.1, mass);
         this.isPinned = this.data.isPinned ?? false;
@@ -51,6 +56,10 @@ export class BaseNode {
     }
 
     setPosition(x, y, z) {
+        if (!isFinite(x) || !isFinite(y) || !isFinite(z)) {
+            console.warn(`BaseNode ${this.id}: Attempted to set invalid position (${x}, ${y}, ${z}). Keeping previous position: (${this.position.x}, ${this.position.y}, ${this.position.z}).`);
+            return;
+        }
         this.position.set(x, y, z);
     }
 


### PR DESCRIPTION
This commit introduces several defensive coding measures to prevent common Three.js errors related to NaN values in geometry and incorrect typed array lengths.

- In `BaseNode.js`:
  - Added `isFinite` checks in the constructor and `setPosition` method. If invalid (NaN or Infinity) position values are provided, a warning is logged, and the position is either defaulted to (0,0,0) or the previous valid position is maintained. This prevents NaN values from being stored in node positions.

- In `Edge.js`:
  - `_createLine()`: `LineGeometry` is now initialized with valid placeholder positions (and gradient colors if applicable by default). This ensures the geometry is never in an "empty" or uninitialized state that could cause errors in subsequent operations like `setColors`.
  - `update()`: Added checks to ensure source and target node positions are finite before using them to set edge geometry positions. If NaNs are detected, a warning is logged, and the edge update is skipped. This prevents `computeBoundingSphere()` from failing due to NaN inputs.
  - `_setGradientColors()`: Strengthened the guard condition before calling `geometry.setColors()`. It now more robustly checks that the position attribute's count and array length are valid and sufficient for the number of points, preventing the 'Invalid typed array length: -6' error.

- In `CurvedEdge.js`:
  - `update()`: Similar to `Edge.js`, added checks for finite source/target node positions.
  - `update()` (gradient color section): Strengthened the guard before `geometry.setColors()` tailored to the number of points in a curved line.

These changes aim to make the graph rendering more robust by handling potential invalid data gracefully, logging warnings for diagnosis, and preventing fatal JavaScript errors in the rendering pipeline.